### PR TITLE
feat: show Slack MCP Server status on App Home in Socket Mode

### DIFF
--- a/claude-agent-sdk/README.md
+++ b/claude-agent-sdk/README.md
@@ -11,7 +11,11 @@ The starter agent interacts with users through four entry points:
 * **Channel @mentions** — Mention the agent in any channel to get a response without leaving the conversation.
 * **Assistant Panel** — Users click _Add Agent_ in Slack, select the agent, and pick from suggested prompts or type a message.
 
-When connected to the [Slack MCP Server](https://github.com/slackapi/slack-mcp-server), the agent can search messages and files, read channel history and threads, send and schedule messages, and create and update canvases. The template also includes one example tool (emoji reactions). Add your own tools to customize it for your use case.
+The template also includes one example tool (emoji reactions). Add your own tools to customize it for your use case.
+
+### Slack MCP Server
+
+When connected to the [Slack MCP Server](https://github.com/slackapi/slack-mcp-server), the agent can search messages and files, read channel history and threads, send and schedule messages, and create and update canvases. When deployed with OAuth (HTTP mode), the agent automatically connects to the Slack MCP Server using the user's token.
 
 ## Setup
 

--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -65,6 +65,25 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         ],
       },
     );
+  } else {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '\ud83d\udd34 *Slack MCP Server is disconnected.* <https://github.com/slack-samples/bolt-js-starter-agent/blob/main/claude-agent-sdk/README.md#slack-mcp-server|Learn how to enable the Slack MCP Server.>',
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+          },
+        ],
+      },
+    );
   }
 
   return { type: 'home', blocks };

--- a/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/claude-agent-sdk/tests/listeners/views/app-home-builder.test.js
@@ -17,11 +17,13 @@ describe('buildAppHomeView', () => {
     assert.strictEqual(view.blocks[1].type, 'section');
   });
 
-  it('does not show MCP status by default', () => {
+  it('shows disconnected status with learn-more link by default', () => {
     const view = buildAppHomeView();
     const mrkdwnTexts = view.blocks.filter((b) => b.type === 'section').map((b) => b.text.text);
-    const hasMcp = mrkdwnTexts.some((t) => t.includes('MCP Server'));
-    assert.strictEqual(hasMcp, false);
+    const mcpText = mrkdwnTexts.find((t) => t.includes('MCP Server'));
+    assert.ok(mcpText);
+    assert.ok(mcpText.includes('disconnected'));
+    assert.ok(mcpText.includes('Learn how to enable'));
   });
 
   it('shows disconnected status when installUrl is provided', () => {

--- a/openai-agents-sdk/README.md
+++ b/openai-agents-sdk/README.md
@@ -11,7 +11,11 @@ The starter agent interacts with users through four entry points:
 * **Channel @mentions** — Mention the agent in any channel to get a response without leaving the conversation.
 * **Assistant Panel** — Users click _Add Agent_ in Slack, select the agent, and pick from suggested prompts or type a message.
 
-When connected to the [Slack MCP Server](https://github.com/slackapi/slack-mcp-server), the agent can search messages and files, read channel history and threads, send and schedule messages, and create and update canvases. The template also includes one example tool (emoji reactions). Add your own tools to customize it for your use case.
+The template also includes one example tool (emoji reactions). Add your own tools to customize it for your use case.
+
+### Slack MCP Server
+
+When connected to the [Slack MCP Server](https://github.com/slackapi/slack-mcp-server), the agent can search messages and files, read channel history and threads, send and schedule messages, and create and update canvases. When deployed with OAuth (HTTP mode), the agent automatically connects to the Slack MCP Server using the user's token.
 
 ## Setup
 

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -65,6 +65,25 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         ],
       },
     );
+  } else {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '\ud83d\udd34 *Slack MCP Server is disconnected.* <https://github.com/slack-samples/bolt-js-starter-agent/blob/main/openai-agents-sdk/README.md#slack-mcp-server|Learn how to enable the Slack MCP Server.>',
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+          },
+        ],
+      },
+    );
   }
 
   return { type: 'home', blocks };

--- a/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
+++ b/openai-agents-sdk/tests/listeners/views/app-home-builder.test.js
@@ -17,11 +17,13 @@ describe('buildAppHomeView', () => {
     assert.strictEqual(view.blocks[1].type, 'section');
   });
 
-  it('does not show MCP status by default', () => {
+  it('shows disconnected status with learn-more link by default', () => {
     const view = buildAppHomeView();
     const mrkdwnTexts = view.blocks.filter((b) => b.type === 'section').map((b) => b.text.text);
-    const hasMcp = mrkdwnTexts.some((t) => t.includes('MCP Server'));
-    assert.strictEqual(hasMcp, false);
+    const mcpText = mrkdwnTexts.find((t) => t.includes('MCP Server'));
+    assert.ok(mcpText);
+    assert.ok(mcpText.includes('disconnected'));
+    assert.ok(mcpText.includes('Learn how to enable'));
   });
 
   it('shows disconnected status when installUrl is provided', () => {


### PR DESCRIPTION
### Summary

This pull request always shows the Slack MCP Server connection status on the App Home, including when the app is running in Socket Mode.

- Previously, the MCP status section was hidden when running in Socket Mode (no `SLACK_CLIENT_ID`). Now it displays as disconnected with a "Learn how to enable the Slack MCP Server" link pointing to the README.
- Adds a `### Slack MCP Server` section to the READMEs so the link has a destination anchor.
- Updates tests to match the new default behavior.

### Preview

<img width="1029" height="260" alt="image" src="https://github.com/user-attachments/assets/7be0f856-c8b2-432a-98d9-ebcd365e013a" />

### Testing

- Open the App Home while running in Socket Mode (`slack run` or `npm start`) and confirm the MCP status shows as disconnected with a learn-more link.
- Open the App Home while running in OAuth mode and confirm connected/disconnected status still works as before.
- Click the "Learn how to enable" link and confirm it navigates to the correct README section.