### PR TITLE
fix: use "the agent" instead of "the assistant" in MCP status text

### DIFF
--- a/claude-agent-sdk/listeners/views/app-home-builder.js
+++ b/claude-agent-sdk/listeners/views/app-home-builder.js
@@ -41,7 +41,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The assistant can search messages, read channels, and more.',
+            text: 'The agent can search messages, read channels, and more.',
           },
         ],
       },
@@ -60,7 +60,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables the agent to search messages, read channels, and more.',
           },
         ],
       },
@@ -79,7 +79,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables the agent to search messages, read channels, and more.',
           },
         ],
       },

--- a/openai-agents-sdk/listeners/views/app-home-builder.js
+++ b/openai-agents-sdk/listeners/views/app-home-builder.js
@@ -41,7 +41,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The assistant can search messages, read channels, and more.',
+            text: 'The agent can search messages, read channels, and more.',
           },
         ],
       },
@@ -60,7 +60,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables the agent to search messages, read channels, and more.',
           },
         ],
       },
@@ -79,7 +79,7 @@ export function buildAppHomeView(installUrl = null, isConnected = false) {
         elements: [
           {
             type: 'mrkdwn',
-            text: 'The Slack MCP Server enables the assistant to search messages, read channels, and more.',
+            text: 'The Slack MCP Server enables the agent to search messages, read channels, and more.',
           },
         ],
       },


### PR DESCRIPTION
### Summary

This pull request updates the App Home MCP status context text to say "the agent" instead of "the assistant" for consistency with how these apps are described throughout the project.

Related to https://github.com/slack-samples/bolt-python-starter-agent/pull/9#discussion_r3102847283

### Testing

- Open the App Home tab and verify the MCP status context text says "the agent" in all three states (connected, disconnected with install URL, disconnected with learn-more link)